### PR TITLE
support custom BOARD_DIR path and/or custom APP_START vector for stm32

### DIFF
--- a/ports/stm32f4/board_flash.c
+++ b/ports/stm32f4/board_flash.c
@@ -136,6 +136,7 @@ static void flash_write(uint32_t dst, const uint8_t *src, int len)
 {
   flash_erase(dst);
 
+  TU_LOG2("Write flash at address %08lX\r\n", dst);
   for ( int i = 0; i < len; i += 4 )
   {
     uint32_t data = *((uint32_t*) ((void*) (src + i)));
@@ -184,13 +185,10 @@ void board_flash_flush(void)
 // TODO not working quite yet
 void board_flash_write (uint32_t addr, void const *data, uint32_t len)
 {
-  // skip matching contents
-  if ( memcmp((void*) addr, data, len) )
-  {
-    HAL_FLASH_Unlock();
-    flash_write(addr, data, len);
-    HAL_FLASH_Lock();
-  }
+  // TODO skip matching contents
+  HAL_FLASH_Unlock();
+  flash_write(addr, data, len);
+  HAL_FLASH_Lock();
 }
 
 void board_flash_erase_app(void)

--- a/ports/stm32f4/boards.c
+++ b/ports/stm32f4/boards.c
@@ -132,13 +132,35 @@ void board_dfu_init(void)
   // Enable USB OTG clock
   __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
-#ifdef USB_NO_VBUS_PIN
-  // Disable VBUS sense
-  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
+#if defined(STM32F446xx) || defined(STM32F469xx) || defined(STM32F479xx) || \
+    defined(STM32F412Zx) || defined(STM32F412Vx) || defined(STM32F412Rx) || \
+    defined(STM32F412Cx) || defined(STM32F413xx) || defined(STM32F423xx)
+
+  #ifdef USB_NO_VBUS_PIN
+    /* Deactivate VBUS Sensing B */
+    USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBDEN;
+
+    /* B-peripheral session valid override enable */
+    USB_OTG_FS->GOTGCTL |= USB_OTG_GOTGCTL_BVALOEN;
+    USB_OTG_FS->GOTGCTL |= USB_OTG_GOTGCTL_BVALOVAL;
+
+    USB_OTG_FS->GCCFG &= ~(USB_OTG_GCCFG_BCDEN);
+  #else
+    // Enable VBUS sense (B device) via pin PA9
+    USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBDEN;
+  #endif
+
 #else
-  // Enable VBUS sense (B device) via pin PA9
-  USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
-  USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
+
+  #ifdef USB_NO_VBUS_PIN
+    // Disable VBUS sense
+    USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_NOVBUSSENS;
+  #else
+    // Enable VBUS sense (B device) via pin PA9
+    USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_NOVBUSSENS;
+    USB_OTG_FS->GCCFG |= USB_OTG_GCCFG_VBUSBSEN;
+  #endif
+
 #endif
 }
 

--- a/ports/stm32f4/boards.c
+++ b/ports/stm32f4/boards.c
@@ -45,7 +45,9 @@ void board_init(void)
   __HAL_RCC_GPIOA_CLK_ENABLE();
   __HAL_RCC_GPIOB_CLK_ENABLE();
   __HAL_RCC_GPIOC_CLK_ENABLE();
+#ifdef __HAL_RCC_GPIOD_CLK_ENABLE
   __HAL_RCC_GPIOD_CLK_ENABLE();
+#endif
 
   GPIO_InitTypeDef  GPIO_InitStruct;
 
@@ -189,7 +191,9 @@ void board_app_jump(void)
   __HAL_RCC_GPIOA_CLK_DISABLE();
   __HAL_RCC_GPIOB_CLK_DISABLE();
   __HAL_RCC_GPIOC_CLK_DISABLE();
+#ifdef __HAL_RCC_GPIOD_CLK_DISABLE
   __HAL_RCC_GPIOD_CLK_DISABLE();
+#endif
 
   HAL_RCC_DeInit();
 

--- a/ports/stm32f4/boards/stm32f412zg_nucleo/board.h
+++ b/ports/stm32f4/boards/stm32f412zg_nucleo/board.h
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PORT              GPIOB
+#define LED_PIN               GPIO_PIN_7    // blue LED
+#define LED_STATE_ON          0
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+//// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//#define NEOPIXEL_PORT         GPIOC
+//#define NEOPIXEL_PIN          GPIO_PIN_0
+//
+//// Brightness percentage from 1 to 255
+//#define NEOPIXEL_BRIGHTNESS   0x10
+
+
+//--------------------------------------------------------------------+
+// Flash
+//--------------------------------------------------------------------+
+
+// Flash size of the board
+#define BOARD_FLASH_SIZE      (1024 * 1024)
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x239A
+#define USB_PID           0x0055
+#define USB_MANUFACTURER  "Adafruit"
+#define USB_PRODUCT       "UF2 Bootloader"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#ifndef UF2_BOARD_ID
+#define UF2_BOARD_ID      "Nucleo-F412"
+#endif
+#define UF2_VOLUME_LABEL  "STMF412BOOT"        // max. 11 characters!
+#define UF2_INDEX_URL     "https://github.com/oliver-joos/tinyuf2"
+
+#define USB_NO_VBUS_PIN   1
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              USART3
+#define UART_CLOCK_ENABLE     __HAL_RCC_USART3_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART3_CLK_DISABLE
+#define UART_GPIO_PORT        GPIOD
+#define UART_GPIO_AF          GPIO_AF7_USART3
+#define UART_TX_PIN           GPIO_PIN_8
+#define UART_RX_PIN           GPIO_PIN_9
+
+//--------------------------------------------------------------------+
+// RCC Clock
+//--------------------------------------------------------------------+
+static inline void clock_init(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* Enable Power Control clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet.  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* Enable HSE Oscillator and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = HSE_VALUE / 1000000;
+  RCC_OscInitStruct.PLL.PLLN = 192;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;       // DIV4 => SYSCLK 48MHz
+  RCC_OscInitStruct.PLL.PLLQ = 4;                   // 4 => USB clock 48MHz
+  HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+     clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1);  // <64MHz:1 <84MHz:2 else 3
+}
+
+#endif

--- a/ports/stm32f4/boards/stm32f412zg_nucleo/board.mk
+++ b/ports/stm32f4/boards/stm32f412zg_nucleo/board.mk
@@ -1,0 +1,12 @@
+CFLAGS += \
+  -DSTM32F412Zx \
+  -DHSE_VALUE=8000000U
+
+SRC_S += \
+	$(ST_CMSIS)/Source/Templates/gcc/startup_stm32f412zx.s
+
+# For flash-jlink target
+JLINK_DEVICE = stm32f412zg
+
+flash: flash-dfu-util
+erase: erase-jlink


### PR DESCRIPTION
A custom BOARD_DIR allows to use tinyuf2 for example as Git submodule in another project that has its own board.h and board.mk.
To set the (absolute or relative) path to your board directory just run:
`make BOARD=<my-board> BOARD_DIR=<path/of/my-board/> ...`

A custom APP_START allows to use tinyuf2 for applications with other start vectors than the hard-coded default in tinyuf2.
To set the start vector of your application just run:
`make APP_START=0x08020000 ...`
or define it in your "board.h" with:
`#define BOARD_FLASH_APP_START 0x08020000`
