### PR TITLE
add support for stm32f412xx

### DIFF
--- a/ports/lpc55/port.mk
+++ b/ports/lpc55/port.mk
@@ -37,7 +37,7 @@ SRC_C += \
 # Port include
 INC += \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
+  $(BOARD_DIR) \
 	$(TOP)/$(SDK_DIR)/CMSIS/Include \
 	$(TOP)/$(MCU_DIR) \
 	$(TOP)/$(MCU_DIR)/project_template \
@@ -49,4 +49,3 @@ INC += \
 	$(TOP)/$(SDK_DIR)/drivers/lpc_iocon \
 	$(TOP)/$(SDK_DIR)/drivers/lpc_rtc \
 	$(TOP)/$(SDK_DIR)/drivers/sctimer
-

--- a/ports/make.mk
+++ b/ports/make.mk
@@ -33,13 +33,18 @@ __check_defined = \
 # can be set manually by custom build such as flash_nuke
 PORT ?= $(notdir $(shell pwd))
 PORT_DIR = ports/$(PORT)
-BOARD_DIR = $(PORT_DIR)/boards/$(BOARD)
 
-ifeq ($(wildcard $(TOP)/$(BOARD_DIR)/),)
+# BOARD must be set manually. BOARD_DIR can be set by a custom build to
+# an absolute path or relative to where make was invoked.
+ifeq ($(BOARD),)
   $(info You must provide a BOARD parameter with 'BOARD=')
-  $(error Invalid BOARD specified)
+  $(error No BOARD specified)
 endif
-
+BOARD_DIR ?= $(TOP)/$(PORT_DIR)/boards/$(BOARD)
+ifeq ($(wildcard $(BOARD_DIR)/),)
+  $(info Check your BOARD parameter and optionally provide BOARD_DIR)
+  $(error Cannot find board directory)
+endif
 
 # Fetch submodules depended by family
 fetch_submodule_if_empty = $(if $(wildcard $(TOP)/lib/$1/*),,$(info $(shell git -C $(TOP)/lib submodule update --init $1)))
@@ -75,13 +80,13 @@ else
 # Bootloader src, board folder and TinyUSB stack
 SRC_C += \
   $(subst $(TOP)/,,$(wildcard $(TOP)/src/*.c)) \
-  $(subst $(TOP)/,,$(wildcard $(TOP)/$(BOARD_DIR)/*.c))
+  $(subst $(TOP)/,,$(wildcard $(BOARD_DIR)/*.c))
 
 # Include
 INC += \
   $(TOP)/src \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR)
+  $(BOARD_DIR)
 
 endif # BUILD_APPLICATION
 
@@ -178,4 +183,4 @@ ifneq ($(SKIP_NANOLIB), 1)
 endif
 
 # Board specific define
-include $(TOP)/$(BOARD_DIR)/board.mk
+include $(BOARD_DIR)/board.mk

--- a/ports/mimxrt10xx/port.mk
+++ b/ports/mimxrt10xx/port.mk
@@ -46,7 +46,7 @@ SRC_S += $(MCU_DIR)/gcc/startup_$(MCU).S
 # Port include
 INC += \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
+  $(BOARD_DIR) \
 	$(TOP)/$(SDK_DIR)/CMSIS/Include \
 	$(TOP)/$(MCU_DIR) \
 	$(TOP)/$(MCU_DIR)/project_template \

--- a/ports/stm32f3/Makefile
+++ b/ports/stm32f3/Makefile
@@ -21,6 +21,11 @@ CFLAGS += \
   -nostdlib -nostartfiles \
   -DCFG_TUSB_MCU=OPT_MCU_STM32F3
 
+# Allow to override application start vector
+ifneq ($(APP_START),)
+  CFLAGS += -DBOARD_FLASH_APP_START=$(APP_START)
+endif
+
 # suppress warning caused by vendor mcu driver
 CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
 

--- a/ports/stm32f3/boards.h
+++ b/ports/stm32f3/boards.h
@@ -35,7 +35,9 @@
 #include "board.h"
 
 // Flash Start Address of Application
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   0x08004000
+#endif
 #define BOARD_RAM_START 0x20000000
 #define BOARD_RAM_SIZE 0x9FFF
 

--- a/ports/stm32f4/Makefile
+++ b/ports/stm32f4/Makefile
@@ -21,6 +21,11 @@ CFLAGS += \
   -nostdlib -nostartfiles \
   -DCFG_TUSB_MCU=OPT_MCU_STM32F4
 
+# Allow to override application start vector
+ifneq ($(APP_START),)
+  CFLAGS += -DBOARD_FLASH_APP_START=$(APP_START)
+endif
+
 # suppress warning caused by vendor mcu driver
 CFLAGS += -Wno-error=cast-align -Wno-error=unused-parameter
 

--- a/ports/stm32f4/board_flash.c
+++ b/ports/stm32f4/board_flash.c
@@ -136,6 +136,7 @@ static void flash_write(uint32_t dst, const uint8_t *src, int len)
 {
   flash_erase(dst);
 
+  TU_LOG2("Write flash at address %08lX\r\n", dst);
   for ( int i = 0; i < len; i += 4 )
   {
     uint32_t data = *((uint32_t*) ((void*) (src + i)));
@@ -184,13 +185,10 @@ void board_flash_flush(void)
 // TODO not working quite yet
 void board_flash_write (uint32_t addr, void const *data, uint32_t len)
 {
-  // skip matching contents
-  if ( memcmp((void*) addr, data, len) )
-  {
-    HAL_FLASH_Unlock();
-    flash_write(addr, data, len);
-    HAL_FLASH_Lock();
-  }
+  // TODO skip matching contents
+  HAL_FLASH_Unlock();
+  flash_write(addr, data, len);
+  HAL_FLASH_Lock();
 }
 
 void board_flash_erase_app(void)

--- a/ports/stm32f4/boards.h
+++ b/ports/stm32f4/boards.h
@@ -35,7 +35,9 @@
 #include "board.h"
 
 // Flash Start Address of Application
+#ifndef BOARD_FLASH_APP_START
 #define BOARD_FLASH_APP_START   0x08010000
+#endif
 
 // Double Reset tap to enter DFU
 #define TINYUF2_DFU_DOUBLE_TAP  1

--- a/ports/stm32f4/boards/stm32f412zg_nucleo/board.h
+++ b/ports/stm32f4/boards/stm32f412zg_nucleo/board.h
@@ -1,0 +1,124 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2018 Ha Thach for Adafruit Industries
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef BOARD_H_
+#define BOARD_H_
+
+//--------------------------------------------------------------------+
+// LED
+//--------------------------------------------------------------------+
+
+#define LED_PORT              GPIOB
+#define LED_PIN               GPIO_PIN_7    // blue LED
+#define LED_STATE_ON          0
+
+//--------------------------------------------------------------------+
+// Neopixel
+//--------------------------------------------------------------------+
+
+//// Number of neopixels
+#define NEOPIXEL_NUMBER       0
+
+//#define NEOPIXEL_PORT         GPIOC
+//#define NEOPIXEL_PIN          GPIO_PIN_0
+//
+//// Brightness percentage from 1 to 255
+//#define NEOPIXEL_BRIGHTNESS   0x10
+
+
+//--------------------------------------------------------------------+
+// Flash
+//--------------------------------------------------------------------+
+
+// Flash size of the board
+#define BOARD_FLASH_SIZE      (1024 * 1024)
+
+//--------------------------------------------------------------------+
+// USB UF2
+//--------------------------------------------------------------------+
+
+#define USB_VID           0x239A
+#define USB_PID           0x0055
+#define USB_MANUFACTURER  "Adafruit"
+#define USB_PRODUCT       "UF2 Bootloader"
+
+#define UF2_PRODUCT_NAME  USB_MANUFACTURER " " USB_PRODUCT
+#ifndef UF2_BOARD_ID
+#define UF2_BOARD_ID      "Nucleo-F412"
+#endif
+#define UF2_VOLUME_LABEL  "STMF412BOOT"        // max. 11 characters!
+#define UF2_INDEX_URL     "https://github.com/oliver-joos/tinyuf2"
+
+#define USB_NO_VBUS_PIN   1
+
+//--------------------------------------------------------------------+
+// UART
+//--------------------------------------------------------------------+
+
+#define UART_DEV              USART3
+#define UART_CLOCK_ENABLE     __HAL_RCC_USART3_CLK_ENABLE
+#define UART_CLOCK_DISABLE    __HAL_RCC_USART3_CLK_DISABLE
+#define UART_GPIO_PORT        GPIOD
+#define UART_GPIO_AF          GPIO_AF7_USART3
+#define UART_TX_PIN           GPIO_PIN_8
+#define UART_RX_PIN           GPIO_PIN_9
+
+//--------------------------------------------------------------------+
+// RCC Clock
+//--------------------------------------------------------------------+
+static inline void clock_init(void)
+{
+  RCC_ClkInitTypeDef RCC_ClkInitStruct;
+  RCC_OscInitTypeDef RCC_OscInitStruct;
+
+  /* Enable Power Control clock */
+  __HAL_RCC_PWR_CLK_ENABLE();
+
+  /* The voltage scaling allows optimizing the power consumption when the device is
+     clocked below the maximum system frequency, to update the voltage scaling value
+     regarding system frequency refer to product datasheet.  */
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE1);
+
+  /* Enable HSE Oscillator and activate PLL with HSE as source */
+  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSE;
+  RCC_OscInitStruct.HSEState = RCC_HSE_ON;
+  RCC_OscInitStruct.PLL.PLLState = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource = RCC_PLLSOURCE_HSE;
+  RCC_OscInitStruct.PLL.PLLM = HSE_VALUE / 1000000;
+  RCC_OscInitStruct.PLL.PLLN = 192;
+  RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;       // DIV4 => SYSCLK 48MHz
+  RCC_OscInitStruct.PLL.PLLQ = 4;                   // 4 => USB clock 48MHz
+  HAL_RCC_OscConfig(&RCC_OscInitStruct);
+
+  /* Select PLL as system clock source and configure the HCLK, PCLK1 and PCLK2
+     clocks dividers */
+  RCC_ClkInitStruct.ClockType = (RCC_CLOCKTYPE_SYSCLK | RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2);
+  RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
+  RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
+  RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
+  RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
+  HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1);  // <64MHz:1 <84MHz:2 else 3
+}
+
+#endif

--- a/ports/stm32f4/boards/stm32f412zg_nucleo/board.mk
+++ b/ports/stm32f4/boards/stm32f412zg_nucleo/board.mk
@@ -1,0 +1,12 @@
+CFLAGS += \
+  -DSTM32F412Zx \
+  -DHSE_VALUE=8000000U
+
+SRC_S += \
+	$(ST_CMSIS)/Source/Templates/gcc/startup_stm32f412zx.s
+
+# For flash-jlink target
+JLINK_DEVICE = stm32f412zg
+
+flash: flash-dfu-util
+erase: erase-jlink

--- a/ports/test_ghostfat/Makefile
+++ b/ports/test_ghostfat/Makefile
@@ -30,6 +30,6 @@ SRC_S +=
 INC += \
   $(TOP)/src \
   $(TOP)/$(PORT_DIR) \
-  $(TOP)/$(BOARD_DIR) \
+  $(BOARD_DIR) \
 
 include ../rules.mk


### PR DESCRIPTION
This branch has been tested successfully on a Nucleo F412ZG board (144 pins!) and on custom boards with F412CE (only 48 pins). It will also help to support boards with F413, F423, F446, F469 and F479.
